### PR TITLE
Active passive

### DIFF
--- a/lib/big_brother.rb
+++ b/lib/big_brother.rb
@@ -9,6 +9,7 @@ require 'sinatra/synchrony'
 
 require 'big_brother/app'
 require 'big_brother/cluster'
+require 'big_brother/active_passive_cluster'
 require 'big_brother/cluster_collection'
 require 'big_brother/configuration'
 require 'big_brother/health_fetcher'

--- a/lib/big_brother/active_passive_cluster.rb
+++ b/lib/big_brother/active_passive_cluster.rb
@@ -1,0 +1,48 @@
+module BigBrother
+  class ActivePassiveCluster < Cluster
+    attr_reader :fwmark, :scheduler, :check_interval, :nodes, :name, :ramp_up_time, :nagios, :backend_mode
+
+    def start_monitoring!
+      BigBrother.logger.info "starting monitoring on cluster #{to_s}"
+      BigBrother.ipvs.start_cluster(@fwmark, @scheduler)
+      BigBrother.ipvs.start_node(@fwmark, active_node.address, 100)
+
+      @monitored = true
+    end
+
+    def active_node
+      @nodes.sort.first
+    end
+
+    def synchronize!
+      ipvs_state = BigBrother.ipvs.running_configuration
+      if ipvs_state.has_key?(fwmark.to_s)
+        resume_monitoring!
+
+        running_active_node_address = ipvs_state[fwmark.to_s].first
+        if running_active_node_address != active_node.address
+          BigBrother.ipvs.stop_node(fwmark, running_active_node_address)
+          BigBrother.ipvs.start_node(fwmark, active_node.address, active_node.weight)
+        end
+      end
+    end
+
+    def monitor_nodes
+      @last_check = Time.now
+      current_active_node = active_node
+      proposed_active_node = @nodes.reject do |node|
+        node.weight = node.monitor(self)
+        node.weight.zero?
+      end.sort.first
+
+      _modify_active_node(current_active_node, proposed_active_node) if current_active_node != proposed_active_node
+      _check_downpage if has_downpage?
+      _notify_nagios if nagios
+    end
+
+    def _modify_active_node(current_active_node, proposed_active_node)
+      BigBrother.ipvs.stop_node(fwmark, current_active_node.address)
+      BigBrother.ipvs.start_node(fwmark, proposed_active_node.address, proposed_active_node.weight)
+    end
+  end
+end

--- a/lib/big_brother/active_passive_cluster.rb
+++ b/lib/big_brother/active_passive_cluster.rb
@@ -32,7 +32,7 @@ module BigBrother
       current_active_node = active_node
       proposed_active_node = @nodes.reject do |node|
         node.weight = node.monitor(self)
-        node.weight.zero?
+        node.weight.to_i.zero?
       end.sort.first
 
       _modify_active_node(current_active_node, proposed_active_node) if current_active_node != proposed_active_node

--- a/lib/big_brother/configuration.rb
+++ b/lib/big_brother/configuration.rb
@@ -8,7 +8,7 @@ module BigBrother
 
       config.inject({}) do |clusters, (cluster_name, cluster_values)|
         cluster_details = _apply_defaults(defaults, cluster_values)
-        clusters.merge(cluster_name => Cluster.new(cluster_name, _deeply_symbolize_keys(cluster_details)))
+        clusters.merge(cluster_name => Cluster.create_cluster(cluster_name, _deeply_symbolize_keys(cluster_details)))
       end
     end
 

--- a/lib/big_brother/node.rb
+++ b/lib/big_brother/node.rb
@@ -34,8 +34,8 @@ module BigBrother
     end
 
     def <=>(other)
-      return 1 if self.weight.zero?
-      return -1 if other.weight.zero?
+      return 1 if self.weight.to_i.zero?
+      return -1 if other.weight.to_i.zero?
       comparison = self.priority <=> other.priority
       if comparison.zero?
        self.address <=> other.address

--- a/lib/big_brother/version.rb
+++ b/lib/big_brother/version.rb
@@ -1,3 +1,3 @@
 module BigBrother
-  VERSION = "0.6.8"
+  VERSION = "0.6.9"
 end

--- a/spec/big_brother/active_passive_cluster_spec.rb
+++ b/spec/big_brother/active_passive_cluster_spec.rb
@@ -1,0 +1,106 @@
+require 'spec_helper'
+
+describe BigBrother::ActivePassiveCluster do
+  describe "#start_monitoring!" do
+    it "starts only the node with the least priority in IPVS" do
+      cluster = Factory.active_passive_cluster(
+        :fwmark => 100,
+        :scheduler => 'wrr',
+        :nodes => [
+          Factory.node(:priority => 0, :address => "127.0.0.1"),
+          Factory.node(:priority => 1, :address => "127.0.0.2"),
+        ],
+      )
+
+      cluster.start_monitoring!
+      @stub_executor.commands.should include('ipvsadm --add-server --fwmark-service 100 --real-server 127.0.0.1 --ipip --weight 100')
+      @stub_executor.commands.should_not include('ipvsadm --add-server --fwmark-service 100 --real-server 127.0.0.2 --ipip --weight 100')
+    end
+  end
+
+  describe "#monitor_nodes" do
+    it "replaces the unhealthy least priority node with the next priority node" do
+      node1 = Factory.node(:priority => 0, :address => "127.0.0.1", :weight => 90)
+      node3 = Factory.node(:priority => 2, :address => "127.0.0.3", :weight => 88)
+      node2 = Factory.node(:priority => 1, :address => "127.0.0.2", :weight => 87)
+      cluster = Factory.active_passive_cluster(:nodes => [node1, node2, node3], :fwmark => 1)
+      node1.stub(:monitor).and_return(0)
+      node2.stub(:monitor).and_return(92)
+      node3.stub(:monitor).and_return(90)
+
+      cluster.monitor_nodes
+
+      cluster.active_node
+      cluster.active_node.address.should == "127.0.0.2"
+    end
+  end
+
+  describe "#resume_monitoring!" do
+    it "marks the cluster as monitored" do
+      cluster = Factory.cluster
+
+      cluster.monitored?.should be_false
+      cluster.resume_monitoring!
+      cluster.monitored?.should be_true
+    end
+  end
+
+  describe "synchronize!" do
+    it "continues to monitor clusters that were already monitored" do
+      BigBrother.ipvs.stub(:running_configuration).and_return({})
+      cluster = Factory.cluster(:fwmark => 1)
+
+      cluster.synchronize!
+
+      cluster.should_not be_monitored
+    end
+
+    it "removes current active node if its priority is no longer the least priority" do
+      BigBrother.ipvs.stub(:running_configuration).and_return({'1' => ['127.0.1.1']})
+      cluster = Factory.active_passive_cluster(
+        :fwmark => 1,
+        :nodes => [
+          Factory.node(:address => '127.0.1.1', :priority => 8),
+          Factory.node(:address => '127.0.0.1', :priority => 3),
+        ],
+      )
+
+      cluster.synchronize!
+
+      @stub_executor.commands.should include("ipvsadm --delete-server --fwmark-service 1 --real-server 127.0.1.1")
+      @stub_executor.commands.should include("ipvsadm --add-server --fwmark-service 1 --real-server 127.0.0.1 --ipip --weight 100")
+    end
+
+    it "removes current active node if the node no longer exist" do
+      BigBrother.ipvs.stub(:running_configuration).and_return({'1' => ['127.0.1.1']})
+      cluster = Factory.active_passive_cluster(
+        :fwmark => 1,
+        :nodes => [
+          Factory.node(:address => '127.0.1.2', :priority => 2),
+          Factory.node(:address => '127.0.0.1', :priority => 3),
+        ],
+      )
+
+      cluster.synchronize!
+
+      @stub_executor.commands.should include("ipvsadm --delete-server --fwmark-service 1 --real-server 127.0.1.1")
+      @stub_executor.commands.should include("ipvsadm --add-server --fwmark-service 1 --real-server 127.0.1.2 --ipip --weight 100")
+    end
+
+    it "does not remove current active node if it has the least priority" do
+      BigBrother.ipvs.stub(:running_configuration).and_return({'1' => ['127.0.1.1']})
+      cluster = Factory.active_passive_cluster(
+        :fwmark => 1,
+        :nodes => [
+          Factory.node(:address => '127.0.1.1', :priority => 0),
+          Factory.node(:address => '127.0.0.1', :priority => 1),
+        ],
+      )
+
+      cluster.synchronize!
+
+      @stub_executor.commands.should be_empty
+      cluster.active_node.address.should == '127.0.1.1'
+    end
+  end
+end

--- a/spec/big_brother/node_spec.rb
+++ b/spec/big_brother/node_spec.rb
@@ -56,6 +56,12 @@ describe BigBrother::Node do
   end
 
   describe "<=>" do
+    it "returns 1 when compared to a node with a nil weight" do
+      node1 = Factory.node(:address => "127.0.0.1", :port => "8000", :priority => 1, :weight => 0)
+      node2 = Factory.node(:address => "127.0.0.2", :port => "8000", :priority => 2, :weight => nil)
+      (node1 <=> node2).should == 1
+    end
+
     it "returns 1 for comparison of an unhealthy node to an healthy one" do
       node1 = Factory.node(:address => "127.0.0.1", :port => "8000", :priority => 1, :weight => 0)
       node2 = Factory.node(:address => "127.0.0.2", :port => "8000", :priority => 2, :weight => 90)

--- a/spec/support/example_config.yml
+++ b/spec/support/example_config.yml
@@ -1,6 +1,7 @@
 ---
 test1:
   check_interval: 1
+  backend_mode: "active_passive"
   scheduler: wrr
   fwmark: 1
   ramp_up_time: 120
@@ -13,9 +14,11 @@ test1:
   - address: 127.0.0.1
     port: 9001
     path: /test/valid
+    priority: 0
   - address: 127.0.0.1
     port: 9002
     path: /test/valid
+    priority: 1
 test2:
   check_interval: 2
   scheduler: wrr

--- a/spec/support/factories/cluster_factory.rb
+++ b/spec/support/factories/cluster_factory.rb
@@ -1,6 +1,6 @@
 class Factory
   def self.cluster(overrides = {})
-    BigBrother::Cluster.new(
+    BigBrother::Cluster.create_cluster(
       overrides.fetch(:name, 'test'),
       {
         :fwmark         => 100,
@@ -10,5 +10,9 @@ class Factory
         :ramp_up_time   => 0
       }.merge(overrides)
     )
+  end
+
+  def self.active_passive_cluster(overrides = {})
+    self.cluster(overrides.merge(:backend_mode => BigBrother::Cluster::ACTIVE_PASSIVE_CLUSTER))
   end
 end


### PR DESCRIPTION
Adding Active/Passive Support to Big Brother Clusters

- To enable active/passive mode, an optional `backend_mode: "active_passive"` configuration directive is added to the big brother cluster config.
  - Active/Passive nodes now take a `priority` field that is used to select the active backend for the cluster. 
  - The active backend for an active/passive cluster is the backend with the lowest priority and positive health response. Should two backends have the same priority, the lowest backend IP address is selected. If none of the backends is healthy, the last active node's health is updated to weight of 0 in ipvs.