### PR TITLE
Remote node fixes

### DIFF
--- a/lib/big_brother/active_active_cluster.rb
+++ b/lib/big_brother/active_active_cluster.rb
@@ -49,6 +49,7 @@ module BigBrother
 
     def synchronize!
       ipvs_state = BigBrother.ipvs.running_configuration
+      @remote_nodes = _fetch_remote_nodes.values if @remote_nodes == []
       if ipvs_state.has_key?(fwmark.to_s)
         resume_monitoring!
 

--- a/lib/big_brother/active_active_cluster.rb
+++ b/lib/big_brother/active_active_cluster.rb
@@ -22,7 +22,6 @@ module BigBrother
         BigBrother.ipvs.start_node(_relay_fwmark, node.address, BigBrother::Node::INITIAL_WEIGHT)
       end
 
-      _monitor_remote_nodes
       @monitored = true
     end
 
@@ -128,13 +127,6 @@ module BigBrother
         next if self.non_egress_locations.include?(node['lb_source_location'])
 
         hsh[node['lb_ip_address']] = BigBrother::Node.new(:address => node['lb_ip_address'], :weight => node['health'])
-      end
-    end
-
-    def _monitor_remote_nodes
-      @remote_nodes = _fetch_remote_nodes.values
-      remote_nodes.each do |node|
-        BigBrother.ipvs.start_node(fwmark, node.address, node.weight)
       end
     end
 

--- a/lib/big_brother/active_active_cluster.rb
+++ b/lib/big_brother/active_active_cluster.rb
@@ -84,7 +84,7 @@ module BigBrother
 
       BigBrother.logger.info "Merging in new active/active cluster #{to_s}"
 
-      @remote_nodes = cluster.remote_nodes
+      @remote_nodes = cluster.remote_nodes if cluster.is_a?(BigBrother::ActiveActiveCluster)
 
       super(cluster)
     end

--- a/lib/big_brother/active_active_cluster.rb
+++ b/lib/big_brother/active_active_cluster.rb
@@ -14,7 +14,7 @@ module BigBrother
     end
 
     def start_monitoring!
-      BigBrother.logger.info "starting monitoring on cluster #{to_s}"
+      BigBrother.logger.info "Starting monitoring on active/active cluster #{to_s}"
       BigBrother.ipvs.start_cluster(@fwmark, @scheduler)
       BigBrother.ipvs.start_cluster(_relay_fwmark, @scheduler)
       local_nodes.each do |node|
@@ -71,6 +71,7 @@ module BigBrother
     def incorporate_state(cluster)
       ipvs_state = BigBrother.ipvs.running_configuration
       if ipvs_state[fwmark.to_s] && ipvs_state[_relay_fwmark.to_s].nil?
+        BigBrother.logger.info "Adding new active/active LB node #{to_s}"
         BigBrother.ipvs.start_cluster(_relay_fwmark, @scheduler)
       end
 
@@ -81,6 +82,7 @@ module BigBrother
         end
       end
 
+      BigBrother.logger.info "Merging in new active/active cluster #{to_s}"
       super(cluster)
     end
 
@@ -98,7 +100,7 @@ module BigBrother
 
     def _add_nodes(addresses, fwmark)
       addresses.each do |address|
-        BigBrother.logger.info "adding #{address} to cluster #{self}"
+        BigBrother.logger.info "Adding #{address} to active/active cluster #{self}"
         BigBrother.ipvs.start_node(fwmark, address, 0)
       end
     end
@@ -145,7 +147,7 @@ module BigBrother
 
     def _remove_nodes(addresses)
       addresses.each do |address|
-        BigBrother.logger.info "removing #{address} to cluster #{self}"
+        BigBrother.logger.info "Removing #{address} from active/active cluster #{self}"
         BigBrother.ipvs.stop_node(fwmark, address)
         BigBrother.ipvs.stop_node(_relay_fwmark, address)
       end

--- a/lib/big_brother/active_active_cluster.rb
+++ b/lib/big_brother/active_active_cluster.rb
@@ -82,6 +82,9 @@ module BigBrother
       end
 
       BigBrother.logger.info "Merging in new active/active cluster #{to_s}"
+
+      @remote_nodes = cluster.remote_nodes
+
       super(cluster)
     end
 

--- a/lib/big_brother/cluster.rb
+++ b/lib/big_brother/cluster.rb
@@ -43,7 +43,7 @@ module BigBrother
     end
 
     def start_monitoring!
-      BigBrother.logger.info "starting monitoring on cluster #{to_s}"
+      BigBrother.logger.info "Starting monitoring on cluster #{to_s}"
       BigBrother.ipvs.start_cluster(@fwmark, @scheduler)
       @nodes.each do |node|
         BigBrother.ipvs.start_node(@fwmark, node.address, BigBrother::Node::INITIAL_WEIGHT)
@@ -53,7 +53,7 @@ module BigBrother
     end
 
     def stop_monitoring!
-      BigBrother.logger.info "stopping monitoring on cluster #{to_s}"
+      BigBrother.logger.info "Stopping monitoring on cluster #{to_s}"
       BigBrother.ipvs.stop_cluster(@fwmark)
 
       @monitored = false
@@ -61,7 +61,7 @@ module BigBrother
     end
 
     def resume_monitoring!
-      BigBrother.logger.info "resuming monitoring on cluster #{to_s}"
+      BigBrother.logger.info "Resuming monitoring on cluster #{to_s}"
       @monitored = true
     end
 
@@ -120,18 +120,19 @@ module BigBrother
       nodes.each do |node|
         node.incorporate_state(another_cluster.find_node(node.address, node.port))
       end
+
       self
     end
 
     def _add_nodes(addresses)
       addresses.each do |address|
-        BigBrother.logger.info "adding #{address} to cluster #{self}"
+        BigBrother.logger.info "Adding #{address} to cluster #{self}"
         BigBrother.ipvs.start_node(fwmark, address, 0)
       end
     end
 
     def _add_maintenance_node
-      BigBrother.logger.info "adding 169.254.254.254 to cluster #{self}"
+      BigBrother.logger.info "Adding downpage to cluster #{self}"
       BigBrother.ipvs.start_node(fwmark, '169.254.254.254', 1)
     end
 
@@ -165,7 +166,7 @@ module BigBrother
 
     def _remove_nodes(addresses)
       addresses.each do |address|
-        BigBrother.logger.info "removing #{address} to cluster #{self}"
+        BigBrother.logger.info "Removing #{address} to cluster #{self}"
         BigBrother.ipvs.stop_node(fwmark, address)
       end
     end

--- a/spec/big_brother/active_active_cluster_spec.rb
+++ b/spec/big_brother/active_active_cluster_spec.rb
@@ -124,6 +124,7 @@ describe BigBrother::ActiveActiveCluster do
       BigBrother::HealthFetcher.stub(:interpol_status).with(node, 100).and_return([{'aggregated_health' => 90,'count' => 1,'lb_ip_address' => '172.27.3.1','lb_url' => 'http://172.27.3.1','health' => 45}])
       BigBrother::HealthFetcher.stub(:interpol_status).with(node, 10100).and_return([{'aggregated_health' => 90,'count' => 1,'lb_ip_address' => '172.27.3.1','lb_url' => 'http://172.27.3.1','health' => 45}])
       cluster.start_monitoring!
+      cluster.monitor_nodes
 
       @stub_executor.commands.should include('ipvsadm --add-server --fwmark-service 100 --real-server 172.27.3.1 --ipip --weight 45')
     end
@@ -146,6 +147,7 @@ describe BigBrother::ActiveActiveCluster do
       BigBrother::HealthFetcher.stub(:interpol_status).with(node, 100).and_return([{'aggregated_health' => 90,'count' => 1,'lb_ip_address' => '172.27.3.2','lb_url' => 'http://172.27.3.2','health' => 55, 'lb_source_location' => 'foo'}])
       BigBrother::HealthFetcher.stub(:interpol_status).with(node, 10100).and_return([{'aggregated_health' => 90,'count' => 1,'lb_ip_address' => '172.27.3.2','lb_url' => 'http://172.27.3.2','health' => 55, 'lb_source_location' => 'foo'}])
       cluster.start_monitoring!
+      cluster.monitor_nodes
 
       @stub_executor.commands.should_not include('ipvsadm --add-server --fwmark-service 100 --real-server 172.27.3.1 --ipip --weight 45')
       @stub_executor.commands.should include('ipvsadm --add-server --fwmark-service 100 --real-server 172.27.3.2 --ipip --weight 55')
@@ -229,6 +231,7 @@ describe BigBrother::ActiveActiveCluster do
       interpol_node = Factory.node(:address => '172.27.3.1', :interpol => true)
       cluster = Factory.active_active_cluster(:fwmark => 100, :nodes => [node, interpol_node])
       cluster.start_monitoring!
+      cluster.monitor_nodes
       @stub_executor.commands.clear
 
       BigBrother::HealthFetcher.stub(:current_health).and_return(56)
@@ -296,6 +299,7 @@ describe BigBrother::ActiveActiveCluster do
       interpol_node = Factory.node(:address => '172.27.3.1', :interpol => true)
       cluster = Factory.active_active_cluster(:fwmark => 100, :nodes => [node, interpol_node], :max_down_ticks => 100)
       cluster.start_monitoring!
+      cluster.monitor_nodes
       @stub_executor.commands.clear
 
       (cluster.max_down_ticks + 1).times do


### PR DESCRIPTION
Currently there are two cases in big_brother where the remote node is deleted and subsequently re-added:

 - When reloading the config with a HUP
 - When restarting the app

This PR fixes both of those cases (and also improves the logging).  @bjhaid: Any comments?