### PR TITLE
Update to new travis infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,4 @@ language: ruby
 rvm:
   - 1.9.2
   - 1.9.3
+sudo: false


### PR DESCRIPTION
As per http://docs.travis-ci.com/user/migrating-from-legacy/ this should migrate us to the new and shiny travis CI.