### PR TITLE
Default active active

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,10 @@
-big-brother (0.9.2-2) UNRELEASED; urgency=low
+big-brother (0.9.3) UNRELEASED; urgency=low
+
+  * Set default cluster type to be ActiveActive
+
+ -- Katy Exline <katy@braintreepayments.com>  Wed, 17 May 2017 15:42:09 +0000
+
+big-brother (0.9.2-2) unstable; urgency=low
 
   * Fix init script
 

--- a/debian/files
+++ b/debian/files
@@ -1,1 +1,1 @@
-big-brother_0.9.2-1_all.deb ruby optional
+big-brother_0.9.3_all.deb ruby optional

--- a/lib/big_brother/cluster.rb
+++ b/lib/big_brother/cluster.rb
@@ -3,7 +3,7 @@ module BigBrother
     module Type
       ActiveActive = "active_active"
       ActivePassive = "active_passive"
-      Default = "cluster"
+      Default = ActiveActive
     end
 
     attr_reader :backend_mode, :check_interval, :fwmark, :interpol_nodes, :local_nodes, :max_down_ticks, :multi_datacenter, :nagios, :name, :nodes, :non_egress_locations, :offset, :ramp_up_time, :remote_nodes, :scheduler

--- a/lib/big_brother/version.rb
+++ b/lib/big_brother/version.rb
@@ -1,3 +1,3 @@
 module BigBrother
-  VERSION = "0.9.2"
+  VERSION = "0.9.3"
 end

--- a/spec/big_brother/cluster_collection_spec.rb
+++ b/spec/big_brother/cluster_collection_spec.rb
@@ -33,7 +33,7 @@ describe BigBrother::ClusterCollection do
 
       existing_cluster = Factory.active_active_cluster(:name => 'existing_cluster')
       collection['existing_cluster'] = existing_cluster
-      cluster_from_config = Factory.cluster(:name => 'existing_cluster')
+      cluster_from_config = Factory.active_passive_cluster(:name => 'existing_cluster')
 
       existing_cluster.should_receive(:stop_relay_fwmark)
 

--- a/spec/big_brother/cluster_spec.rb
+++ b/spec/big_brother/cluster_spec.rb
@@ -33,7 +33,7 @@ describe BigBrother::Cluster do
 
     it "invalidates recorded weights, so it properly updates after a stop/start" do
       node = Factory.node(:address => '127.0.0.1')
-      cluster = Factory.cluster(:fwmark => '100', :nodes => [node])
+      cluster = Factory.cluster(:fwmark => 100, :nodes => [node])
       cluster.start_monitoring!
       cluster.monitor_nodes
 

--- a/spec/big_brother/ticker_spec.rb
+++ b/spec/big_brother/ticker_spec.rb
@@ -45,7 +45,7 @@ describe BigBrother::Ticker do
         BigBrother::Ticker.tick
         BigBrother::Ticker.tick
 
-        @stub_executor.commands.should == ["ipvsadm --edit-server --fwmark-service 100 --real-server 127.0.0.1 --ipip --weight 74"]
+        @stub_executor.commands.should == ["ipvsadm --edit-server --fwmark-service 100 --real-server 127.0.0.1 --ipip --weight 74", "ipvsadm --edit-server --fwmark-service 10100 --real-server 127.0.0.1 --ipip --weight 74"]
       end
     end
 


### PR DESCRIPTION
We are moving towards making the applications active-active. By setting the Default type to a value of cluster, this produced some unexpected behaviors when services were shifted around. Particularly the remote fwmarks weren't getting deleted when they needed to. This solves that.