### PR TITLE
bugfix - Prevent exception when a node is added to a cluster

### DIFF
--- a/lib/big_brother/cluster.rb
+++ b/lib/big_brother/cluster.rb
@@ -252,6 +252,10 @@ module BigBrother
         original_cluster._stop_node(removed_node)
       end
 
+      (nodes & original_cluster.nodes).each do |node|
+        node.incorporate_state(original_cluster.find_node(node.address, node.port))
+      end
+
       if ipvs_state[fwmark.to_s] && ipvs_state.fetch(_relay_fwmark.to_s, []).empty?
         _active_nodes.each do |node|
           actual_node = find_node(node.address, node.port)
@@ -262,10 +266,6 @@ module BigBrother
       if original_cluster.multi_datacenter && !self.multi_datacenter
         original_cluster.stop_relay_fwmark
         @remote_nodes = []
-      end
-
-      nodes.each do |node|
-        node.incorporate_state(original_cluster.find_node(node.address, node.port))
       end
 
       self

--- a/lib/big_brother/cluster_collection.rb
+++ b/lib/big_brother/cluster_collection.rb
@@ -16,18 +16,18 @@ module BigBrother
 
       ipvs_state = BigBrother.ipvs.running_configuration
 
-      new_clusters.each do |cluster_name, cluster|
+      new_clusters.each do |cluster_name, new_cluster|
         if @clusters.key?(cluster_name)
           current_cluster = @clusters[cluster_name]
-          current_cluster.stop_relay_fwmark if !current_cluster.instance_of?(BigBrother::Cluster) && cluster.instance_of?(BigBrother::Cluster)
+          current_cluster.stop_relay_fwmark if !current_cluster.instance_of?(BigBrother::Cluster) && new_cluster.instance_of?(BigBrother::Cluster)
 
-          @clusters[cluster_name] = cluster.incorporate_state(@clusters[cluster_name])
+          @clusters[cluster_name] = new_cluster.incorporate_state(@clusters[cluster_name])
         else
-          @clusters[cluster_name] = cluster
+          @clusters[cluster_name] = new_cluster
 
-          if ipvs_state.key?(cluster.fwmark.to_s)
-            BigBrother.logger.info("resuming previously running cluster from kernel state (#{cluster.fwmark})")
-            cluster.start_monitoring!
+          if ipvs_state.key?(new_cluster.fwmark.to_s)
+            BigBrother.logger.info("resuming previously running cluster from kernel state (#{new_cluster.fwmark})")
+            new_cluster.start_monitoring!
           end
         end
       end

--- a/lib/big_brother/node.rb
+++ b/lib/big_brother/node.rb
@@ -37,6 +37,10 @@ module BigBrother
       @interpol
     end
 
+    def to_s
+      "#{@address}:#{@port}"
+    end
+
     def ==(other)
       address == other.address && port == other.port
     end

--- a/spec/big_brother/active_active_cluster_spec.rb
+++ b/spec/big_brother/active_active_cluster_spec.rb
@@ -424,6 +424,40 @@ describe "active_active clusters" do
 
       @stub_executor.commands.should be_empty
     end
+
+    it "adds and starts nodes" do
+      BigBrother.ipvs.stub(:running_configuration).and_return({'1' => ['127.0.0.1']})
+
+      original_node1 = Factory.node(:address => '127.0.0.1')
+      original_cluster = Factory.cluster(:name => 'test', :fwmark => 1, :nodes => [original_node1])
+
+      new_node1 = Factory.node(:address => '127.0.0.1')
+      new_node2 = Factory.node(:address => '127.0.1.1')
+      new_cluster = Factory.cluster(:name => 'test', :fwmark => 1, :nodes => [new_node1, new_node2])
+
+      new_cluster.should_receive(:_start_node).with(new_node1).never
+      new_cluster.should_receive(:_start_node).with(new_node2).once
+
+      retval = new_cluster.incorporate_state(original_cluster)
+      retval.nodes.should == [new_node1, new_node2]
+    end
+
+    it "removes and stops nodes" do
+      BigBrother.ipvs.stub(:running_configuration).and_return({'1' => ['127.0.0.1', '127.0.1.1']})
+
+      original_node1 = Factory.node(:address => '127.0.0.1')
+      original_node2 = Factory.node(:address => '127.0.1.1')
+      original_cluster = Factory.cluster(:name => 'test', :fwmark => 1, :nodes => [original_node1, original_node2])
+
+      new_node1 = Factory.node(:address => '127.0.1.1')
+      new_cluster = Factory.cluster(:name => 'test', :fwmark => 1, :nodes => [new_node1])
+
+      original_cluster.should_receive(:_stop_node).with(original_node1).once
+      original_cluster.should_receive(:_stop_node).with(original_node2).never
+
+      retval = new_cluster.incorporate_state(original_cluster)
+      retval.nodes.should == [new_node1]
+    end
   end
 
   describe "#stop_relay_fwmark" do

--- a/spec/big_brother/cluster_spec.rb
+++ b/spec/big_brother/cluster_spec.rb
@@ -354,40 +354,6 @@ describe BigBrother::Cluster do
 
       retval.should == config_cluster
     end
-
-    it "adds and starts nodes" do
-      BigBrother.ipvs.stub(:running_configuration).and_return({'1' => ['127.0.0.1']})
-
-      original_node1 = Factory.node(:address => '127.0.0.1')
-      original_cluster = Factory.cluster(:name => 'test', :fwmark => 1, :nodes => [original_node1])
-
-      new_node1 = Factory.node(:address => '127.0.0.1')
-      new_node2 = Factory.node(:address => '127.0.1.1')
-      new_cluster = Factory.cluster(:name => 'test', :fwmark => 1, :nodes => [new_node1, new_node2])
-
-      new_cluster.should_receive(:_start_node).with(new_node1).never
-      new_cluster.should_receive(:_start_node).with(new_node2).once
-
-      retval = new_cluster.incorporate_state(original_cluster)
-      retval.nodes.should == [new_node1, new_node2]
-    end
-
-    it "removes and stops nodes" do
-      BigBrother.ipvs.stub(:running_configuration).and_return({'1' => ['127.0.0.1', '127.0.1.1']})
-
-      original_node1 = Factory.node(:address => '127.0.0.1')
-      original_node2 = Factory.node(:address => '127.0.1.1')
-      original_cluster = Factory.cluster(:name => 'test', :fwmark => 1, :nodes => [original_node1, original_node2])
-
-      new_node1 = Factory.node(:address => '127.0.1.1')
-      new_cluster = Factory.cluster(:name => 'test', :fwmark => 1, :nodes => [new_node1])
-
-      original_cluster.should_receive(:_stop_node).with(original_node1).once
-      original_cluster.should_receive(:_stop_node).with(original_node2).never
-
-      retval = new_cluster.incorporate_state(original_cluster)
-      retval.nodes.should == [new_node1]
-    end
   end
 
   describe "combined_weight" do

--- a/spec/big_brother/cluster_spec.rb
+++ b/spec/big_brother/cluster_spec.rb
@@ -354,6 +354,40 @@ describe BigBrother::Cluster do
 
       retval.should == config_cluster
     end
+
+    it "adds and starts nodes" do
+      BigBrother.ipvs.stub(:running_configuration).and_return({'1' => ['127.0.0.1']})
+
+      original_node1 = Factory.node(:address => '127.0.0.1')
+      original_cluster = Factory.cluster(:name => 'test', :fwmark => 1, :nodes => [original_node1])
+
+      new_node1 = Factory.node(:address => '127.0.0.1')
+      new_node2 = Factory.node(:address => '127.0.1.1')
+      new_cluster = Factory.cluster(:name => 'test', :fwmark => 1, :nodes => [new_node1, new_node2])
+
+      new_cluster.should_receive(:_start_node).with(new_node1).never
+      new_cluster.should_receive(:_start_node).with(new_node2).once
+
+      retval = new_cluster.incorporate_state(original_cluster)
+      retval.nodes.should == [new_node1, new_node2]
+    end
+
+    it "removes and stops nodes" do
+      BigBrother.ipvs.stub(:running_configuration).and_return({'1' => ['127.0.0.1', '127.0.1.1']})
+
+      original_node1 = Factory.node(:address => '127.0.0.1')
+      original_node2 = Factory.node(:address => '127.0.1.1')
+      original_cluster = Factory.cluster(:name => 'test', :fwmark => 1, :nodes => [original_node1, original_node2])
+
+      new_node1 = Factory.node(:address => '127.0.1.1')
+      new_cluster = Factory.cluster(:name => 'test', :fwmark => 1, :nodes => [new_node1])
+
+      original_cluster.should_receive(:_stop_node).with(original_node1).once
+      original_cluster.should_receive(:_stop_node).with(original_node2).never
+
+      retval = new_cluster.incorporate_state(original_cluster)
+      retval.nodes.should == [new_node1]
+    end
   end
 
   describe "combined_weight" do


### PR DESCRIPTION
When adding a new node to an existing cluster, we receive an `undefined method #address on Nil` exception in `BigBrother::Cluster#incorporate_state`.  The primary issue is that we're trying to lookup a node to `start` from the `original_cluster`, which is no longer the source of truth of nodes.

Importantly, the code calls `new_cluster.incorporate_changes(original_cluster)` to effect config changes.  The variable naming contributed to the confusion, so `new_cluster` and `original_cluster` were made more explicit. 

Also, this bug was hidden because `BigBrother.ipvs.running_configuration` in specs did not reflect the `original_configuration` values.  Stubbing it out accordingly covers this code path.