### PR TITLE
Bugfixes for issues around cluster changes

### DIFF
--- a/lib/big_brother/cluster.rb
+++ b/lib/big_brother/cluster.rb
@@ -11,7 +11,7 @@ module BigBrother
     def initialize(name, attributes = {})
       @name = name
       @fwmark = attributes[:fwmark]
-      @cluster_mode = attributes.fetch(:backend_mode, Type::Default)
+      @cluster_mode = @backend_mode = attributes.fetch(:backend_mode, Type::Default)
       @multi_datacenter = attributes.fetch(:multi_datacenter, @cluster_mode == Type::ActiveActive)
       @scheduler = attributes[:scheduler]
       @check_interval = attributes.fetch(:check_interval, 1)
@@ -32,7 +32,6 @@ module BigBrother
       @ramp_up_time = attributes.fetch(:ramp_up_time, 60)
       @has_downpage = attributes[:has_downpage]
       @nagios = attributes[:nagios]
-      @backend_mode = attributes[:backend_mode]
     end
 
     def active_passive?

--- a/lib/big_brother/cluster.rb
+++ b/lib/big_brother/cluster.rb
@@ -36,11 +36,11 @@ module BigBrother
     end
 
     def active_passive?
-      @backend_mode == Type::ActivePassive
+      @cluster_mode == Type::ActivePassive
     end
 
     def active_active?
-      @backend_mode == Type::ActiveActive
+      @cluster_mode == Type::ActiveActive
     end
 
     def _coerce_node(node_config)

--- a/lib/big_brother/cluster.rb
+++ b/lib/big_brother/cluster.rb
@@ -254,7 +254,7 @@ module BigBrother
 
       _active_nodes.each do |node|
         original_node = original_cluster.find_node(node.address, node.port)
-        node.incorporate_state(original_node)
+        node.incorporate_state(original_node) unless original_node.nil?
 
         if original_node.nil? && active_active?
           _start_node(node)

--- a/lib/big_brother/cluster.rb
+++ b/lib/big_brother/cluster.rb
@@ -237,7 +237,7 @@ module BigBrother
       @down_file.exists?
     end
 
-    def incorporate_state(cluster)
+    def incorporate_state(original_cluster)
       ipvs_state = BigBrother.ipvs.running_configuration
       if ipvs_state[fwmark.to_s] && ipvs_state[_relay_fwmark.to_s].nil?
         BigBrother.logger.info "Adding new remote relay cluster #{to_s}"
@@ -246,18 +246,18 @@ module BigBrother
 
       if ipvs_state[fwmark.to_s] && ipvs_state.fetch(_relay_fwmark.to_s, []).empty?
         _active_nodes.each do |node|
-          actual_node = cluster.find_node(node.address, node.port)
+          actual_node = original_cluster.find_node(node.address, node.port)
           BigBrother.ipvs.start_node(_relay_fwmark, actual_node.address, actual_node.weight)
         end
       end
 
-      if cluster.multi_datacenter && !self.multi_datacenter
-        cluster.stop_relay_fwmark
+      if original_cluster.multi_datacenter && !self.multi_datacenter
+        original_cluster.stop_relay_fwmark
         @remote_nodes = []
       end
 
       nodes.each do |node|
-        node.incorporate_state(cluster.find_node(node.address, node.port))
+        node.incorporate_state(original_cluster.find_node(node.address, node.port))
       end
 
       self

--- a/lib/big_brother/cluster.rb
+++ b/lib/big_brother/cluster.rb
@@ -252,7 +252,7 @@ module BigBrother
         BigBrother.ipvs.start_cluster(_relay_fwmark, @scheduler)
       end
 
-      nodes.each do |node|
+      _active_nodes.each do |node|
         original_node = original_cluster.find_node(node.address, node.port)
         node.incorporate_state(original_node)
 

--- a/lib/big_brother/cluster_collection.rb
+++ b/lib/big_brother/cluster_collection.rb
@@ -16,18 +16,18 @@ module BigBrother
 
       ipvs_state = BigBrother.ipvs.running_configuration
 
-      new_clusters.each do |cluster_name, cluster|
+      new_clusters.each do |cluster_name, new_cluster|
         if @clusters.key?(cluster_name)
           current_cluster = @clusters[cluster_name]
-          current_cluster.stop_relay_fwmark if !current_cluster.instance_of?(BigBrother::Cluster) && cluster.instance_of?(BigBrother::Cluster)
+          current_cluster.stop_relay_fwmark if !current_cluster.instance_of?(BigBrother::Cluster) && new_cluster.instance_of?(BigBrother::Cluster)
 
-          @clusters[cluster_name] = cluster.incorporate_state(@clusters[cluster_name])
+          @clusters[cluster_name] = new_cluster.incorporate_state(@clusters[cluster_name])
         else
-          @clusters[cluster_name] = cluster
+          @clusters[cluster_name] = new_cluster
 
-          if ipvs_state.key?(cluster.fwmark.to_s)
-            BigBrother.logger.info("resuming previously running cluster from kernel state (#{cluster.fwmark})")
-            cluster.start_monitoring!
+          if ipvs_state.key?(new_cluster.fwmark.to_s)
+            BigBrother.logger.info("resuming previously running cluster from kernel state (#{new_cluster.fwmark})")
+            new_cluster.start_monitoring!
           end
         end
       end

--- a/lib/big_brother/node.rb
+++ b/lib/big_brother/node.rb
@@ -30,7 +30,7 @@ module BigBrother
     end
 
     def invalidate_weight!
-      @weight = nil
+      @weight = 0
     end
 
     def interpol?

--- a/lib/big_brother/node.rb
+++ b/lib/big_brother/node.rb
@@ -33,6 +33,10 @@ module BigBrother
       @weight = 0
     end
 
+    def initialize_weight!
+      @weight = INITIAL_WEIGHT
+    end
+
     def interpol?
       @interpol
     end

--- a/spec/big_brother/active_active_cluster_spec.rb
+++ b/spec/big_brother/active_active_cluster_spec.rb
@@ -424,6 +424,40 @@ describe "active_active clusters" do
 
       @stub_executor.commands.should be_empty
     end
+
+    it "adds and starts nodes" do
+      BigBrother.ipvs.stub(:running_configuration).and_return({'1' => ['127.0.0.1']})
+
+      original_node1 = Factory.node(:address => '127.0.0.1')
+      original_cluster = Factory.cluster(:name => 'test', :fwmark => 1, :nodes => [original_node1])
+
+      new_node1 = Factory.node(:address => '127.0.0.1')
+      new_node2 = Factory.node(:address => '127.0.1.1')
+      new_cluster = Factory.cluster(:name => 'test', :fwmark => 1, :nodes => [new_node1, new_node2])
+
+      new_cluster.should_receive(:_start_node).with(new_node1).never
+      new_cluster.should_receive(:_start_node).with(new_node2).once
+
+      retval = new_cluster.incorporate_state(original_cluster)
+      retval.nodes.should == [new_node1, new_node2]
+    end
+
+    it "removes and stops nodes" do
+      BigBrother.ipvs.stub(:running_configuration).and_return({'1' => ['127.0.0.1', '127.0.1.1']})
+
+      original_node1 = Factory.node(:address => '127.0.0.1')
+      original_node2 = Factory.node(:address => '127.0.1.1')
+      original_cluster = Factory.cluster(:name => 'test', :fwmark => 1, :nodes => [original_node1, original_node2])
+
+      new_node1 = Factory.node(:address => '127.0.1.1')
+      new_cluster = Factory.cluster(:name => 'test', :fwmark => 1, :nodes => [new_node1])
+
+      original_cluster.should_receive(:_stop_node).with(original_node1).once
+      original_cluster.should_receive(:_stop_node).with(original_node2).never
+
+      retval = new_cluster.incorporate_state(original_cluster)
+      retval.nodes.should == [new_node1]
+    end
   end
 
   describe "#stop_relay_fwmark" do

--- a/spec/big_brother/active_active_cluster_spec.rb
+++ b/spec/big_brother/active_active_cluster_spec.rb
@@ -433,7 +433,7 @@ describe "active_active clusters" do
 
       new_node1 = Factory.node(:address => '127.0.0.1')
       new_node2 = Factory.node(:address => '127.0.1.1')
-      new_cluster = Factory.cluster(:name => 'test', :fwmark => 1, :nodes => [new_node1, new_node2])
+      new_cluster = Factory.active_active_cluster(:name => 'test', :fwmark => 1, :nodes => [new_node1, new_node2])
 
       new_cluster.should_receive(:_start_node).with(new_node1).never
       new_cluster.should_receive(:_start_node).with(new_node2).once

--- a/spec/big_brother/active_passive_cluster_spec.rb
+++ b/spec/big_brother/active_passive_cluster_spec.rb
@@ -180,10 +180,10 @@ describe "active_passive clusters" do
 
       active_node = Factory.node(:address => '127.0.0.1', :priority => 0)
       original_passive_node = Factory.node(:address => '127.0.0.2', :priority => 50)
-      original_cluster = Factory.cluster(:name => 'test', :fwmark => 1, :nodes => [active_node, original_passive_node])
+      original_cluster = Factory.active_passive_cluster(:name => 'test', :fwmark => 1, :nodes => [active_node, original_passive_node])
 
       new_passive_node = Factory.node(:address => '127.0.0.3', :priority => 50)
-      new_cluster = Factory.cluster(:name => 'test', :fwmark => 1, :nodes => [active_node, new_passive_node])
+      new_cluster = Factory.active_passive_cluster(:name => 'test', :fwmark => 1, :nodes => [active_node, new_passive_node])
 
       new_cluster.should_receive(:_start_node).with(original_passive_node).never
       new_cluster.should_receive(:_start_node).with(new_passive_node).never

--- a/spec/big_brother/app_spec.rb
+++ b/spec/big_brother/app_spec.rb
@@ -6,6 +6,11 @@ module BigBrother
       App
     end
 
+    def tick
+      BigBrother::Ticker.instance_variable_set(:@outstanding_ticks, 0)
+      BigBrother::Ticker.tick
+    end
+
     describe "/" do
       it "returns the list of configured clusters and their status" do
         BigBrother::HealthFetcher.stub(:current_health).and_return(99)
@@ -17,6 +22,8 @@ module BigBrother
         )
         BigBrother.clusters['three'].start_monitoring!
         BigBrother.clusters['four'] = Factory.cluster(:name => 'four', :fwmark => 4)
+
+        tick
 
         get "/"
         last_response.status.should == 200
@@ -39,6 +46,7 @@ module BigBrother
       end
 
       it "returns 'Running: true' and the combined weight when the cluster is running" do
+        BigBrother::HealthFetcher.stub(:current_health).and_return(100)
         BigBrother.clusters['test'] = Factory.cluster(
           :name => 'test',
           :nodes => [
@@ -47,8 +55,8 @@ module BigBrother
             Factory.node,
           ]
         )
-
         put "/cluster/test"
+        tick
         get "/cluster/test"
 
         last_response.status.should == 200
@@ -90,6 +98,7 @@ CombinedWeight: 300
       end
 
       it "returns 'Running: true' and the combined weight when the cluster is running" do
+        BigBrother::HealthFetcher.stub(:current_health).and_return(100)
         BigBrother.clusters['test'] = Factory.cluster(
           :name => 'test',
           :nodes => [
@@ -100,6 +109,7 @@ CombinedWeight: 300
         )
 
         put "/cluster/test"
+        tick
         get "/cluster/test/status"
 
         last_response.status.should == 200

--- a/spec/big_brother/cluster_spec.rb
+++ b/spec/big_brother/cluster_spec.rb
@@ -57,7 +57,7 @@ describe BigBrother::Cluster do
       @stub_executor.commands.should include("ipvsadm --edit-server --fwmark-service 100 --real-server 127.0.0.1 --ipip --weight 15")
     end
 
-    it "it properly updates after a stop/start even if set to 0" do
+    it "properly updates after a stop/start even if measured health is 0" do
       node = Factory.node(:address => '127.0.0.1')
       cluster = Factory.cluster(:fwmark => 100, :nodes => [node], :weight => 0)
       cluster.start_monitoring!
@@ -381,7 +381,7 @@ describe BigBrother::Cluster do
       retval.should == config_cluster
     end
 
-    it "Stops the relay fwmark if shifting from multi_datacenter" do
+    it "stops the relay fwmark if shifting from multi_datacenter" do
       original_cluster = Factory.active_active_cluster(:multi_datacenter => true, :nodes => [Factory.node(:address => '127.0.0.1')])
       new_cluster = Factory.active_active_cluster(:multi_datacenter => false, :nodes => [Factory.node(:address => '127.0.0.1')])
 
@@ -390,7 +390,7 @@ describe BigBrother::Cluster do
       new_cluster.incorporate_state(original_cluster)
     end
 
-    it "Removes remote nodes if shifting from multi_datacenter" do
+    it "removes remote nodes if shifting from multi_datacenter" do
       BigBrother.ipvs.stub(:running_configuration).and_return({'1' => ['127.0.0.1', '172.27.1.3']})
       original_cluster = Factory.active_active_cluster(:multi_datacenter => true, :fwmark => 1, :nodes => [Factory.node(:address => '127.0.0.1')])
       original_cluster.instance_variable_set(:@remote_nodes, [Factory.node(:address => '172.27.1.3')])

--- a/spec/big_brother/cluster_spec.rb
+++ b/spec/big_brother/cluster_spec.rb
@@ -31,6 +31,17 @@ describe BigBrother::Cluster do
       @stub_executor.commands.should include("ipvsadm --delete-service --fwmark-service 100")
     end
 
+    it "invalidates recorded weights and sets them to 0 after a stop" do
+      node = Factory.node(:address => '127.0.0.1')
+      cluster = Factory.cluster(:fwmark => 100, :nodes => [node])
+      cluster.start_monitoring!
+      cluster.monitor_nodes
+
+      cluster.stop_monitoring!
+
+      node.weight.should be_zero
+    end
+
     it "invalidates recorded weights, so it properly updates after a stop/start" do
       node = Factory.node(:address => '127.0.0.1')
       cluster = Factory.cluster(:fwmark => 100, :nodes => [node])

--- a/spec/big_brother/cluster_spec.rb
+++ b/spec/big_brother/cluster_spec.rb
@@ -365,6 +365,28 @@ describe BigBrother::Cluster do
 
       retval.should == config_cluster
     end
+
+    it "Stops the relay fwmark if shifting from multi_datacenter" do
+      original_cluster = Factory.active_active_cluster(:multi_datacenter => true, :nodes => [Factory.node(:address => '127.0.0.1')])
+      new_cluster = Factory.active_active_cluster(:multi_datacenter => false, :nodes => [Factory.node(:address => '127.0.0.1')])
+
+      original_cluster.should_receive(:stop_relay_fwmark)
+
+      new_cluster.incorporate_state(original_cluster)
+    end
+
+    it "Removes remote nodes if shifting from multi_datacenter" do
+      BigBrother.ipvs.stub(:running_configuration).and_return({'1' => ['127.0.0.1', '172.27.1.3']})
+      original_cluster = Factory.active_active_cluster(:multi_datacenter => true, :fwmark => 1, :nodes => [Factory.node(:address => '127.0.0.1')])
+      original_cluster.instance_variable_set(:@remote_nodes, [Factory.node(:address => '172.27.1.3')])
+
+      new_cluster = Factory.active_active_cluster(:multi_datacenter => false, :fwmark => 1, :nodes => [Factory.node(:address => '127.0.0.1')])
+      new_cluster.instance_variable_set(:@remote_nodes, [Factory.node(:address => '172.27.1.3')])
+
+      new_cluster.incorporate_state(original_cluster)
+
+      new_cluster.remote_nodes.should be_empty
+    end
   end
 
   describe "combined_weight" do

--- a/spec/big_brother/node_spec.rb
+++ b/spec/big_brother/node_spec.rb
@@ -10,6 +10,15 @@ describe BigBrother::Node do
     end
   end
 
+  describe "#initialize_weight!" do
+    it "sets the weight to the node class' initial weight value" do
+      node = Factory.node(:address => '127.0.0.1', :weight => 90)
+      node.initialize_weight!
+
+      node.weight.should == BigBrother::Node::INITIAL_WEIGHT
+    end
+  end
+
   describe "#monitor" do
     it "a node's health should increase linearly over the specified ramp up time" do
       BigBrother::HealthFetcher.stub(:current_health).and_return(100)

--- a/spec/big_brother/node_spec.rb
+++ b/spec/big_brother/node_spec.rb
@@ -1,6 +1,14 @@
 require 'spec_helper'
 
 describe BigBrother::Node do
+  describe "#invalidate_weight!" do
+    it "sets the weight to zero" do
+      node = Factory.node(:address => '127.0.0.1', :weight => 90)
+      node.invalidate_weight!
+
+      node.weight.should be_zero
+    end
+  end
 
   describe "#monitor" do
     it "a node's health should increase linearly over the specified ramp up time" do


### PR DESCRIPTION
* Use the nodes states of a newly configured cluster to determine state and which nodes to stop/start.
* Set weight to `0` rather than `nil` when invalidating a node's.
* Set `cluster_mode` to be same value as `backend_mode`. This ensures that `active_active?` and `active_passive?` work as expected.
