### PR TITLE
Add status_detail route to report on node health

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,5 @@ sudo: false
 notifications:
   email:
     - blue-ci-notifications@getbraintree.com
+before_install:
+  - gem update bundler

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+big-brother (0.9.6-1) unstable; urgency=low
+
+  * Add status_detail route to report on node health
+  * Ensure Travis CI has an updated version of bundler
+
+ -- Tom Christiansen-Salameh <tomcs@buildw64.chi.braintreepayments.com>  Wed, 06 Sep 2017 12:55:40 +0000
+
 big-brother (0.9.5-2) unstable; urgency=low
 
   * Version bump

--- a/lib/big_brother/app.rb
+++ b/lib/big_brother/app.rb
@@ -29,8 +29,26 @@ Stopped:
       _cluster_status
     end
 
+    get "/cluster/:name/status_detail" do |name|
+      _cluster_status_detail
+    end
+
     def _cluster_status
       [200, "Running: #{@cluster.monitored?}\nCombinedWeight: #{@cluster.combined_weight}\n"]
+    end
+
+    def _cluster_status_detail
+      status = {
+        "nodes" => Hash[
+                      @cluster.nodes.map do |node|
+                        [node.address, node.weight]
+                      end
+                    ],
+        "cluster" => @cluster.name,
+        "running" => @cluster.monitored?
+      }
+
+      [200, status.to_json]
     end
 
     put "/cluster/:name" do |name|

--- a/lib/big_brother/version.rb
+++ b/lib/big_brother/version.rb
@@ -1,3 +1,3 @@
 module BigBrother
-  VERSION = "0.9.5-2"
+  VERSION = "0.9.6"
 end


### PR DESCRIPTION
This commit adds a status_detail route that reports the health and address of each node in the cluster. This is so tools that check service health can easily determine the number of live nodes and average weight across nodes, which isn't possible when we only report combined
weight and whether the cluster is running.