### PR TITLE
blue-4021 Stopping event loop when a healthy node has been found

### DIFF
--- a/lib/big_brother/health_fetcher.rb
+++ b/lib/big_brother/health_fetcher.rb
@@ -32,7 +32,7 @@ module BigBrother
           result = http
           if http.response_header.status == 200
             BigBrother.logger.debug("Request to #{url} was successful")
-            this.instance_variable_set(:@ended, true) #This halts the loop
+            EM.stop_event_loop
           end
           iter.next
         end

--- a/lib/big_brother/health_fetcher.rb
+++ b/lib/big_brother/health_fetcher.rb
@@ -17,7 +17,11 @@ module BigBrother
       end
 
       response = _first_interpol_response(urls)
-      response.response_header.status == 200 ? JSON.parse(response.response) : []
+      if response
+        response.response_header.status == 200 ? JSON.parse(response.response) : []
+      else
+        []
+      end
     rescue JSON::ParserError
       []
     end
@@ -29,16 +33,17 @@ module BigBrother
         http = EventMachine::HttpRequest.new(url, :connect_timeout => 2, :inactivity_timeout => 2).aget
         this = self
         http.callback do
-          result = http
           if http.response_header.status == 200
             BigBrother.logger.debug("Request to #{url} was successful")
-            EM.stop_event_loop
+            result = http
           end
           iter.next
         end
 
         http.errback do
-          result = http
+          if ! result
+            result = http
+          end
           iter.next
         end
       end

--- a/spec/big_brother/health_fetcher_spec.rb
+++ b/spec/big_brother/health_fetcher_spec.rb
@@ -74,6 +74,37 @@ HTTP
       ]
     end
 
+    it "works with multiple interpol nodes and returns data from one even if a node is down or slow" do
+      StubServer.new(<<-HTTP, 0, 8081)
+HTTP/1.0 200 OK
+Connection: close
+
+[{"aggregated_health":0,"count":1,"lb_ip_address":"load1.stq","lb_url":"http://load1.stq:80/lvs.json","health":0}]
+HTTP
+      StubServer.new(<<-HTTP, 0, 8082)
+HTTP/1.0 200 OK
+Connection: close
+
+[{"aggregated_health":0,"count":1,"lb_ip_address":"load1.stq","lb_url":"http://load1.stq:80/lvs.json","health":0}]
+HTTP
+      StubServer.new(<<-HTTP, 3, 8083)
+HTTP/1.0 200 OK
+Connection: close
+
+[{"aggregated_health":0,"count":1,"lb_ip_address":"load1.stq","lb_url":"http://load1.stq:80/lvs.json","health":0}]
+HTTP
+      BigBrother::HealthFetcher.interpol_status(
+        [
+          Factory.node(:address => "127.0.0.1", :port => 8083, :interpol => true, :path => '/fwmark'),
+          Factory.node(:address => "127.0.0.1", :port => 8081, :interpol => true, :path => '/fwmark'),
+          Factory.node(:address => "127.0.0.1", :port => 8082, :interpol => true, :path => '/fwmark'),
+        ],
+        'test'
+      ).should == [
+        {"aggregated_health" => 0,"count" => 1,"lb_ip_address" => "load1.stq","lb_url" => "http://load1.stq:80/lvs.json","health" => 0}
+      ]
+    end
+
     it "returns nodes as a list" do
       StubServer.new(<<-HTTP)
 HTTP/1.0 200 OK


### PR DESCRIPTION
Currently the event loop will run until all nodes respond or until the
timeout (2 seconds) is reached. The change found here will cause the
event loop to halt the moment we have a good node, preventing us from
waiting for slow/dead nodes.

Previously, slow/dead nodes would take the longest and then stomp on the
`result` variable, leading to interpol nodes being removed from BigBro
even when we still had one node responding.

@bjhaid @ssgelm 