### PR TITLE
Wrap EM.synchrony call in EM.add_timer(0)

### DIFF
--- a/lib/big_brother/cli.rb
+++ b/lib/big_brother/cli.rb
@@ -64,11 +64,11 @@ module BigBrother
         end
 
         Signal.trap("HUP") do
-          EM.synchrony do
-            EM.add_timer(0) do
+          EM.add_timer(0) do
+            EM.synchrony do
               BigBrother.logger.info "HUP trapped. Reconfiguring big brother"
+              BigBrother.reconfigure
             end
-            BigBrother.reconfigure
           end
         end
       end


### PR DESCRIPTION
Currently under ruby 2.0+ big_brother crashes when sent a SIGHUP because synchronize is not safe to be called in a signal handler. This change causes the call to execute during the next event loop, thereby preventing it from running in the handler itself and preventing the crash. More info at https://github.com/eventmachine/eventmachine/issues/418 and https://bugs.ruby-lang.org/issues/7917.

It seems @mrak tried to do this in fcddf596f633ad22769bd7b884d79606f3fb701e but it didn't work because the EM.add_timer(0) was in the EM.synchrony and not the other way around.